### PR TITLE
Make struct fields nullable by default (with an override)

### DIFF
--- a/src/codegen/modules.jl
+++ b/src/codegen/modules.jl
@@ -6,6 +6,7 @@ end
 
 Base.@kwdef struct Options
     always_use_modules::Bool = true
+    force_required::Union{Nothing,Dict{String,Set{String}}} = nothing
 end
 
 proto_module_file_name(path::AbstractString) = string(proto_module_name(path), ".jl")
@@ -214,9 +215,10 @@ end
 function protojl(
     relative_paths::Union{<:AbstractString,<:AbstractVector{<:AbstractString}},
     search_directories::Union{<:AbstractString,<:AbstractVector{<:AbstractString},Nothing}=nothing,
-    output_directory::Union{AbstractString,Nothing}=nothing;
+    output_directory::Union{<:AbstractString,Nothing}=nothing;
     include_vendored_wellknown_types::Bool=true,
     always_use_modules::Bool=true,
+    force_required::Union{Nothing,Dict{<:AbstractString,Set{<:AbstractString}}}=nothing,
 )
     if isnothing(search_directories)
         search_directories = ["."]
@@ -248,7 +250,7 @@ function protojl(
     end
 
     ns = NamespaceTrie(values(parsed_files))
-    options = Options(always_use_modules)
+    options = Options(always_use_modules, force_required)
     create_namespaced_packages(ns, output_directory, parsed_files, options)
     return nothing
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ import ProtocolBuffers
     include("test_encode.jl")
     include("test_decode.jl")
     include("test_parser.jl")
+    include("test_codegen.jl")
     include("test_protojl.jl")
 
     @testset "Aqua" begin

--- a/test/test_codegen.jl
+++ b/test/test_codegen.jl
@@ -229,7 +229,7 @@ end
 
     @testset "Basic enum codegen" begin
         s, p, ctx = translate_simple_proto("enum A { a = 0; b = 1; }")
-        @test codegen_str(p.definitions["B"], ctx) == """
+        @test codegen_str(p.definitions["A"], ctx) == """
         @enumx A a=0 b=1
         """
     end

--- a/test/test_codegen.jl
+++ b/test/test_codegen.jl
@@ -1,0 +1,236 @@
+using ProtocolBuffers
+using ProtocolBuffers.CodeGenerators: Options, ResolvedProtoFile, translate, namespace
+using ProtocolBuffers.CodeGenerators: import_paths, Context, generate_struct, codegen
+using ProtocolBuffers.Parsers: parse_proto_file, ParserState, Parsers
+using ProtocolBuffers.Lexers: Lexer
+using Test
+
+function generate_struct_str(args...)
+    io = IOBuffer()
+    generate_struct(io, args...)
+    return String(take!(io))
+end
+
+function codegen_str(args...)
+    io = IOBuffer()
+    codegen(io, args...)
+    return String(take!(io))
+end
+
+function translate_simple_proto(str::String, options=Options())
+    buf = IOBuffer()
+    l = Lexer(IOBuffer(str), "main")
+    p = parse_proto_file(ParserState(l))
+    r = ResolvedProtoFile("main", p)
+    d = Dict{String, ResolvedProtoFile}("main" => r)
+    translate(buf, r, d, options)
+    s = String(take!(buf))
+    s = join(filter!(!startswith(r"#|$^"), split(s, '\n')), '\n')
+    imports = Set{String}(Iterators.map(i->namespace(d[i]), import_paths(p)))
+    ctx = Context(p, r.import_path, imports, d, copy(p.cyclic_definitions), options)
+    s, p, ctx
+end
+
+function translate_simple_proto(str::String, deps::Dict{String,String}, options=Options())
+    buf = IOBuffer()
+    l = Lexer(IOBuffer(str), "main")
+    p = parse_proto_file(ParserState(l))
+    r = ResolvedProtoFile("main", p)
+    d = Dict{String, ResolvedProtoFile}("main" => r)
+    for (k, v) in deps
+        get!(d, k) do
+            l = Lexer(IOBuffer(v), k)
+            ResolvedProtoFile(k, parse_proto_file(ParserState(l)))
+        end
+    end
+    d["main"] =  r
+    translate(buf, r, d, options)
+    s = String(take!(buf))
+    s = join(filter!(!startswith(r"#|$^"), split(s, '\n')), '\n')
+    imports = Set{String}(Iterators.map(i->namespace(d[i]), import_paths(p)))
+    ctx = Context(p, r.import_path, imports, d, copy(p.cyclic_definitions), options)
+    s, d, ctx
+end
+
+@testset "translate" begin
+    @testset "Minimal proto file" begin
+        s, p, ctx = translate_simple_proto("", Options(always_use_modules=false))
+        @test s == """
+        import ProtocolBuffers as PB
+        using ProtocolBuffers: OneOf
+        using EnumX: @enumx"""
+
+        s, p, ctx = translate_simple_proto("", Options(always_use_modules=true))
+        @test s == """
+        module main_pb
+        import ProtocolBuffers as PB
+        using ProtocolBuffers: OneOf
+        using EnumX: @enumx
+        end # module"""
+    end
+
+    @testset "Minimal proto file with file imports" begin
+        s, p, ctx = translate_simple_proto("import \"path/to/a\";", Dict("path/to/a" => ""), Options(always_use_modules=false))
+        @test s == """
+        include("a_pb.jl")
+        import ProtocolBuffers as PB
+        using ProtocolBuffers: OneOf
+        using EnumX: @enumx"""
+
+        s, p, ctx = translate_simple_proto("import \"path/to/a\";", Dict("path/to/a" => ""), Options(always_use_modules=true))
+        @test s == """
+        module main_pb
+        include("a_pb.jl")
+        import a_pb
+        import ProtocolBuffers as PB
+        using ProtocolBuffers: OneOf
+        using EnumX: @enumx
+        end # module"""
+    end
+
+    @testset "Minimal proto file with package imports" begin
+        s, p, ctx = translate_simple_proto("import \"path/to/a\";", Dict("path/to/a" => "package p;"), Options(always_use_modules=false))
+        @test s == """
+        include($(repr(joinpath("p", "P_PB.jl"))))
+        import .P_PB
+        import ProtocolBuffers as PB
+        using ProtocolBuffers: OneOf
+        using EnumX: @enumx"""
+
+        s, p, ctx = translate_simple_proto("import \"path/to/a\";", Dict("path/to/a" => "package p;"), Options(always_use_modules=true))
+        @test s == """
+        module main_pb
+        include($(repr(joinpath("p", "P_PB.jl"))))
+        import .P_PB
+        import ProtocolBuffers as PB
+        using ProtocolBuffers: OneOf
+        using EnumX: @enumx
+        end # module"""
+    end
+
+    @testset "`force_required` option makes optional fields required" begin
+        s, p, ctx = translate_simple_proto("message A {} message B { A a = 1; }", Options(force_required=Dict("main" => Set(["B.a"]))))
+        @test generate_struct_str(p.definitions["B"], ctx) == """
+        struct B
+            a::A
+        end
+        """
+
+        s, p, ctx = translate_simple_proto("message A {} message B { optional A a = 1; }", Options(force_required=Dict("main" => Set(["B.a"]))))
+        @test generate_struct_str(p.definitions["B"], ctx) == """
+        struct B
+            a::A
+        end
+        """
+    end
+
+    @testset "Struct fields are optional when not marked required" begin
+        s, p, ctx = translate_simple_proto("message A {} message B { A a = 1; }")
+        @test generate_struct_str(p.definitions["B"], ctx) == """
+        struct B
+            a::Union{Nothing,A}
+        end
+        """
+
+        s, p, ctx = translate_simple_proto("message A {} message B { optional A a = 1; }")
+        @test generate_struct_str(p.definitions["B"], ctx) == """
+        struct B
+            a::Union{Nothing,A}
+        end
+        """
+
+        s, p, ctx = translate_simple_proto("message A {} message B { required A a = 1; }")
+        @test generate_struct_str(p.definitions["B"], ctx) == """
+        struct B
+            a::A
+        end
+        """
+    end
+
+    @testset "Struct fields are optional when the type is self referential" begin
+        s, p, ctx = translate_simple_proto("message B { B a = 1; }")
+        @test generate_struct_str(p.definitions["B"], ctx) == """
+        struct B <: var"##AbstractB"
+            a::Union{Nothing,B}
+        end
+        """
+
+        s, p, ctx = translate_simple_proto("message B { B a = 1; }", Options(force_required=Dict("main" => Set(["B.a"]))))
+        @test generate_struct_str(p.definitions["B"], ctx) == """
+        struct B <: var"##AbstractB"
+            a::Union{Nothing,B}
+        end
+        """
+
+        s, p, ctx = translate_simple_proto("message B { required B a = 1; }")
+        @test generate_struct_str(p.definitions["B"], ctx) == """
+        struct B <: var"##AbstractB"
+            a::Union{Nothing,B}
+        end
+        """
+
+        s, p, ctx = translate_simple_proto("message B { optional B a = 1; }")
+        @test generate_struct_str(p.definitions["B"], ctx) == """
+        struct B <: var"##AbstractB"
+            a::Union{Nothing,B}
+        end
+        """
+    end
+
+    @testset "Struct fields are optional when the type mutually recusrive dependency" begin
+        s, p, ctx = translate_simple_proto("message A { B b = 1; } message B { A a = 1; }")
+        @test generate_struct_str(p.definitions["B"], ctx) == """
+        struct B{T1<:var"##AbstractA"} <: var"##AbstractB"
+            a::Union{Nothing,T1}
+        end
+        """
+        @test generate_struct_str(p.definitions["A"], ctx) == """
+        struct A <: var"##AbstractA"
+            b::Union{Nothing,B}
+        end
+        """
+
+        s, p, ctx = translate_simple_proto("message A { B b = 1; } message B { A a = 1; }", Options(force_required=Dict("main" => Set(["B.a"]))))
+        @test generate_struct_str(p.definitions["B"], ctx) == """
+        struct B{T1<:var"##AbstractA"} <: var"##AbstractB"
+            a::Union{Nothing,T1}
+        end
+        """
+        @test generate_struct_str(p.definitions["A"], ctx) == """
+        struct A <: var"##AbstractA"
+            b::Union{Nothing,B}
+        end
+        """
+
+        s, p, ctx = translate_simple_proto("message A { B b = 1; } message B { required A a = 1; }")
+        @test generate_struct_str(p.definitions["B"], ctx) == """
+        struct B{T1<:var"##AbstractA"} <: var"##AbstractB"
+            a::Union{Nothing,T1}
+        end
+        """
+        @test generate_struct_str(p.definitions["A"], ctx) == """
+        struct A <: var"##AbstractA"
+            b::Union{Nothing,B}
+        end
+        """
+
+        s, p, ctx = translate_simple_proto("message A { B b = 1; } message B { optional A a = 1; }")
+        @test generate_struct_str(p.definitions["B"], ctx) == """
+        struct B{T1<:var"##AbstractA"} <: var"##AbstractB"
+            a::Union{Nothing,T1}
+        end
+        """
+        @test generate_struct_str(p.definitions["A"], ctx) == """
+        struct A <: var"##AbstractA"
+            b::Union{Nothing,B}
+        end
+        """
+    end
+
+    @testset "Basic enum codegen" begin
+        s, p, ctx = translate_simple_proto("enum A { a = 0; b = 1; }")
+        @test codegen_str(p.definitions["B"], ctx) == """
+        @enumx A a=0 b=1
+        """
+    end
+end


### PR DESCRIPTION
Now all struct fields are optional by default (as they should in proto3). When the user knows that field will be always sent over the wire, they can tell `protojl` to treat that field as `required` (which is a proto2 concept). This will make the struct field have type `T` instead of `Union{Nothing,T}` which might be desirable. This is the api:
```julia
protojl(...; force_required=Dict("import/proto/path" => Set(["StructName.field_name", ...]), ...))
```