### PR TITLE
Add `add_kwarg_constructors` option & default value tests

### DIFF
--- a/src/ProtocolBuffers.jl
+++ b/src/ProtocolBuffers.jl
@@ -4,10 +4,13 @@ import TranscodingStreams
 using TOML
 
 # TODO:
+# - Docs!
+# - Optimization pass (esp allocations in encode methods)
+# - Snoopi/Compilation latency pass
 # - configs for protojl:
 #    * Allow the user to use inline string for specific message string fields
-#    * Allow the user to mark dict values and non-optional messages as Union{nothing,T} to
-#      be more resilient to cases when the sender sends an incomplete message etc.
+#    * Make Dicts robust to missing values where possible
+# - Groups
 # - Services & RPC
 # - Extensions
 
@@ -85,9 +88,7 @@ end
 Return a named tuple of fields names to their respective default values from the original proto message type.
 Fields of `OneOf` types are expanded as they don't map to any single default value.
 
-`BufferedVector` and `Ref` types must be dereferenced (`x[]`) to get the true default value. These containers are used
-for performance and dispatch reasons during the decoding stage. Note that dereferencing an unassigned `Ref` type (`Ref{T}()`)
-will throw an error -- they are used for non-optional message fields which don't have a default value.
+`required` message-fields do not have a default value and are represented as `Ref{MyFieldMessageType}()`.
 """
 function default_values(::Type{T}) where T
     return (;)

--- a/src/codegen/decode_methods.jl
+++ b/src/codegen/decode_methods.jl
@@ -89,7 +89,7 @@ function generate_decode_method(io, t::MessageType, ctx)
     println(io, "function PB.decode(d::PB.AbstractProtoDecoder, ::Type{$(safename(t))})")
     has_fields = !isempty(t.fields)
     for field in t.fields
-        println(io, "    ", jl_fieldname(field), " = ", jl_default_value(field, ctx))
+        println(io, "    ", jl_fieldname(field), " = ", jl_init_value(field, ctx))
     end
     println(io, "    while !PB.message_done(d)")
     println(io, "        field_number, wire_type = PB.decode_tag(d)")

--- a/src/codegen/defaults.jl
+++ b/src/codegen/defaults.jl
@@ -1,13 +1,32 @@
-function jl_default_value(field::FieldType, ctx)
+function jl_init_value(field::FieldType, ctx)
     if _is_repeated_field(field)
         return "PB.BufferedVector{$(jl_typename(field.type, ctx))}()"
     else
-        return jl_type_default(field, ctx)
+        return jl_type_init_value(field, ctx)
     end
 end
-jl_type_default(f::FieldType{StringType}, ctx) = get(f.options, "default", "\"\"")
-jl_type_default(f::FieldType{BoolType}, ctx)   = get(f.options, "default", "false")
-function jl_type_default(f::FieldType{<:AbstractProtoFloatType}, ctx)
+
+function jl_default_value(field::FieldType, ctx)
+    if _is_repeated_field(field)
+        return "Vector{$(jl_typename(field.type, ctx))}()"
+    else
+        return jl_type_default_value(field, ctx)
+    end
+end
+
+function _is_optional_referenced_message(field::Union{FieldType{ReferencedType},GroupType}, ctx)
+    struct_name = ctx._toplevel_name[]
+    (field.type.name == struct_name || field.type.name in ctx._curr_cyclic_defs) && return true
+    if field.label == Parsers.OPTIONAL || field.label == Parsers.DEFAULT
+        return !_should_force_required(string(struct_name, ".", jl_fieldname(field)), ctx)
+    end
+    return false
+end
+
+
+jl_type_default_value(f::FieldType{StringType}, ctx) = get(f.options, "default", "\"\"")
+jl_type_default_value(f::FieldType{BoolType}, ctx)   = get(f.options, "default", "false")
+function jl_type_default_value(f::FieldType{<:AbstractProtoFloatType}, ctx)
     type_name = jl_typename(f, ctx)
     default = get(f.options, "default", nothing)
     if default === nothing
@@ -33,7 +52,7 @@ _jl_parse_default_int(::Union{Int32Type,SInt32Type,SFixed32Type}, s::String) = p
 _jl_parse_default_int(::Union{Int64Type,SInt64Type,SFixed64Type}, s::String) = parse(Int64, s)
 _jl_parse_default_int(::Union{UInt32Type,Fixed32Type}, s::String) = parse(UInt32, s)
 _jl_parse_default_int(::Union{UInt64Type,Fixed64Type}, s::String) = parse(UInt64, s)
-function jl_type_default(f::FieldType{<:AbstractProtoNumericType}, ctx)
+function jl_type_default_value(f::FieldType{<:AbstractProtoNumericType}, ctx)
     type_name = jl_typename(f, ctx)
     default = get(f.options, "default", nothing)
     if default === nothing
@@ -41,38 +60,67 @@ function jl_type_default(f::FieldType{<:AbstractProtoNumericType}, ctx)
     end
     return string(type_name, '(', repr(_jl_parse_default_int(f.type, default)), ')')
 end
-function jl_type_default(f::FieldType{BytesType}, ctx)
+function jl_type_default_value(f::FieldType{BytesType}, ctx)
     out = get(f.options, "default", nothing)
     return isnothing(out) ? "UInt8[]" : "b$(out)"
 end
-function jl_type_default(f::FieldType{ReferencedType}, ctx)
+function jl_type_default_value(f::FieldType{MapType}, ctx)
+    return "Dict{$(jl_typename(f.type.keytype, ctx)),$(jl_typename(f.type.valuetype, ctx))}()"
+end
+
+function jl_type_init_value(f::FieldType{ReferencedType}, ctx)
     if _is_enum(f.type, ctx)
         default = get(f.options, "default") do
             definition = _get_referenced_type(f.type, ctx)::EnumType
             string(first(keys(definition.elements)))
         end
         return "$(jl_typename(f.type, ctx)[1:end-2]).$(default)"
-    else # message, AFAIK services shouldn't be referenced
-        if f.type.name in ctx.proto_file.cyclic_definitions || f.label == Parsers.OPTIONAL
+    else # message
+        if _is_optional_referenced_message(f, ctx)
             return "Ref{Union{Nothing,$(jl_typename(f.type, ctx))}}(nothing)"
         end
         return "Ref{$(jl_typename(f.type, ctx))}()"
     end
 end
-# end
-function jl_type_default(f::FieldType{MapType}, ctx)
-    return "Dict{$(jl_typename(f.type.keytype, ctx)),$(jl_typename(f.type.valuetype, ctx))}()"
-end
-function jl_default_value(::OneOfType, ctx)
-    return "nothing"
-end
-function jl_default_value(f::GroupType, ctx)
+
+jl_init_value(::OneOfType, ctx) = "nothing"
+jl_default_value(::OneOfType, ctx) = "nothing"
+
+function jl_init_value(f::GroupType, ctx)
     if _is_repeated_field(f)
         return "PB.BufferedVector{$(jl_typename(f.type, ctx))}()"
     else
-        if f.type.name in ctx.proto_file.cyclic_definitions || f.label == Parsers.OPTIONAL
+        if _is_optional_referenced_message(f, ctx)
             return "Ref{Union{Nothing,$(jl_typename(f.type, ctx))}}(nothing)"
         end
         return "Ref{$(jl_typename(f.type, ctx))}()"
+    end
+end
+
+jl_type_init_value(field, ctx) = jl_type_default_value(field, ctx)
+
+function jl_type_default_value(f::FieldType{ReferencedType}, ctx)
+    if _is_enum(f.type, ctx)
+        default = get(f.options, "default") do
+            definition = _get_referenced_type(f.type, ctx)::EnumType
+            string(first(keys(definition.elements)))
+        end
+        return "$(jl_typename(f.type, ctx)[1:end-2]).$(default)"
+    else # message
+        if _is_optional_referenced_message(f, ctx)
+            return "nothing"
+        end
+        return nothing
+    end
+end
+
+function jl_default_value(f::GroupType, ctx)
+    if _is_repeated_field(f)
+        return "Vector{$(jl_typename(f.type, ctx))}()"
+    else
+        if _is_optional_referenced_message(f, ctx)
+            return "nothing"
+        end
+        return nothing
     end
 end

--- a/src/codegen/encode_methods.jl
+++ b/src/codegen/encode_methods.jl
@@ -5,20 +5,20 @@ function encode_condition(f::FieldType, ctx)
         return _encode_condition(f, ctx)
     end
 end
-_encode_condition(f::FieldType, ctx) = "x.$(jl_fieldname(f)) != $(jl_default_value(f, ctx))"
+_encode_condition(f::FieldType, ctx) = "x.$(jl_fieldname(f)) != $(jl_init_value(f, ctx))"
 function _encode_condition(f::FieldType{T}, ctx) where {T<:Union{StringType,BytesType}}
     default = get(f.options, "default", nothing)
     if default === nothing
         return "!isempty(x.$(jl_fieldname(f)))"
     end
-    return "x.$(jl_fieldname(f)) != $(jl_default_value(f, ctx))"
+    return "x.$(jl_fieldname(f)) != $(jl_init_value(f, ctx))"
 end
 _encode_condition(f::OneOfType, ctx) = "!isnothing(x.$(jl_fieldname(f)))"
 function _encode_condition(f::FieldType{ReferencedType}, ctx)
     if _is_message(f.type, ctx)
         return "!isnothing(x.$(jl_fieldname(f)))"
     else
-        return "x.$(jl_fieldname(f)) != $(jl_default_value(f, ctx))"
+        return "x.$(jl_fieldname(f)) != $(jl_init_value(f, ctx))"
     end
 end
 

--- a/src/codegen/modules.jl
+++ b/src/codegen/modules.jl
@@ -7,6 +7,7 @@ end
 Base.@kwdef struct Options
     always_use_modules::Bool = true
     force_required::Union{Nothing,Dict{String,Set{String}}} = nothing
+    add_kwarg_constructors::Bool = false
 end
 
 proto_module_file_name(path::AbstractString) = string(proto_module_name(path), ".jl")
@@ -218,7 +219,8 @@ function protojl(
     output_directory::Union{<:AbstractString,Nothing}=nothing;
     include_vendored_wellknown_types::Bool=true,
     always_use_modules::Bool=true,
-    force_required::Union{Nothing,Dict{<:AbstractString,Set{<:AbstractString}}}=nothing,
+    force_required::Union{Nothing,<:Dict{<:AbstractString,<:Set{<:AbstractString}}}=nothing,
+    add_kwarg_constructors::Bool=false,
 )
     if isnothing(search_directories)
         search_directories = ["."]
@@ -248,9 +250,8 @@ function protojl(
         isdir(output_directory) || error("`output_directory` \"$output_directory\" doesn't exist")
         output_directory = abspath(output_directory)
     end
-
     ns = NamespaceTrie(values(parsed_files))
-    options = Options(always_use_modules, force_required)
+    options = Options(always_use_modules, force_required, add_kwarg_constructors)
     create_namespaced_packages(ns, output_directory, parsed_files, options)
     return nothing
 end

--- a/src/codegen/types.jl
+++ b/src/codegen/types.jl
@@ -97,13 +97,13 @@ end
 _is_message(t::ReferencedType, ctx) = _get_referenced_type_type!(t, ctx) == "message"
 _is_enum(t::ReferencedType, ctx)    = _get_referenced_type_type!(t, ctx) == "enum"
 
-_needs_type_params(struct_name::String, f::FieldType{ReferencedType}, ctx) = f.type.name in ctx._curr_cyclic_defs && f.type.name != struct_name
-_needs_type_params(::String, f::FieldType, ctx) = false
-_needs_type_params(::String, f::OneOfType, ctx) = true
-_needs_type_params(::String, f::GroupType, ctx) = f.name in ctx._curr_cyclic_defs
-function _needs_type_params(struct_name::String, f::FieldType{MapType}, ctx)
+_needs_type_params(f::FieldType{ReferencedType}, ctx) = f.type.name in ctx._curr_cyclic_defs && f.type.name != ctx._toplevel_name[]
+_needs_type_params(f::FieldType, ctx) = false
+_needs_type_params(f::OneOfType, ctx) = true
+_needs_type_params(f::GroupType, ctx) = f.name in ctx._curr_cyclic_defs
+function _needs_type_params(f::FieldType{MapType}, ctx)
     if isa(f.type.valuetype, ReferencedType)
-        return f.type.valuetype.name in ctx._curr_cyclic_defs && f.type.valuetype.name != struct_name
+        return f.type.valuetype.name in ctx._curr_cyclic_defs && f.type.valuetype.name != ctx._toplevel_name[]
     end
     return false
 end
@@ -117,7 +117,7 @@ function _get_type_bound(f::OneOfType, ctx)
     for o in f.fields
         name = jl_typename(o.type, ctx)
         get!(seen, name) do
-            push!(union_types, name in ctx._curr_cyclic_defs ? abstract_type_name(name) : name)
+            push!(union_types, name in ctx._curr_cyclic_defs || name == ctx._toplevel_name[] ? abstract_type_name(name) : name)
             nothing
         end
     end
@@ -130,7 +130,7 @@ function _maybe_subtype(name)
 end
 
 function get_type_params(t::MessageType, ctx)
-    out = [field.name => _get_type_bound(field, ctx) for field in t.fields if _needs_type_params(t.name, field, ctx)]
+    out = [field.name => _get_type_bound(field, ctx) for field in t.fields if _needs_type_params(field, ctx)]
     type_params = Dict(k => ParamMetadata(string("T", i), v) for (i, (k, v)) in enumerate(out))
     return type_params
 end

--- a/test/test_codegen.jl
+++ b/test/test_codegen.jl
@@ -20,8 +20,13 @@ function translate_simple_proto(str::String, options=Options())
     s = String(take!(buf))
     s = join(filter!(!startswith(r"#|$^"), split(s, '\n')), '\n')
     imports = Set{String}(Iterators.map(i->namespace(d[i]), import_paths(p)))
-    ctx = Context(p, r.import_path, imports, d, copy(p.cyclic_definitions), options)
-    s, p, ctx
+    ctx = Context(
+        p, r.import_path, imports, d,
+        copy(p.cyclic_definitions),
+        Ref(get(p.sorted_definitions, length(p.sorted_definitions), "")),
+        options
+    )
+    return s, p, ctx
 end
 
 function translate_simple_proto(str::String, deps::Dict{String,String}, options=Options())
@@ -41,8 +46,13 @@ function translate_simple_proto(str::String, deps::Dict{String,String}, options=
     s = String(take!(buf))
     s = join(filter!(!startswith(r"#|$^"), split(s, '\n')), '\n')
     imports = Set{String}(Iterators.map(i->namespace(d[i]), import_paths(p)))
-    ctx = Context(p, r.import_path, imports, d, copy(p.cyclic_definitions), options)
-    s, d, ctx
+    ctx = Context(
+        p, r.import_path, imports, d,
+        copy(p.cyclic_definitions),
+        Ref(get(p.sorted_definitions, length(p.sorted_definitions), "")),
+        options
+    )
+    return s, d, ctx
 end
 
 @testset "translate" begin
@@ -103,41 +113,56 @@ end
 
     @testset "`force_required` option makes optional fields required" begin
         s, p, ctx = translate_simple_proto("message A {} message B { A a = 1; }", Options(force_required=Dict("main" => Set(["B.a"]))))
+        ctx._toplevel_name[] = "B"
         @test generate_struct_str(p.definitions["B"], ctx) == """
         struct B
             a::A
         end
         """
+        @test CodeGenerators.jl_default_value(p.definitions["B"].fields[1], ctx) === nothing
+        @test CodeGenerators.jl_init_value(p.definitions["B"].fields[1], ctx) == "Ref{A}()"
 
         s, p, ctx = translate_simple_proto("message A {} message B { optional A a = 1; }", Options(force_required=Dict("main" => Set(["B.a"]))))
+        ctx._toplevel_name[] = "B"
         @test generate_struct_str(p.definitions["B"], ctx) == """
         struct B
             a::A
         end
         """
+        @test CodeGenerators.jl_default_value(p.definitions["B"].fields[1], ctx) === nothing
+        @test CodeGenerators.jl_init_value(p.definitions["B"].fields[1], ctx) == "Ref{A}()"
     end
 
     @testset "Struct fields are optional when not marked required" begin
         s, p, ctx = translate_simple_proto("message A {} message B { A a = 1; }")
+        ctx._toplevel_name[] = "B"
         @test generate_struct_str(p.definitions["B"], ctx) == """
         struct B
             a::Union{Nothing,A}
         end
         """
+        @test CodeGenerators.jl_default_value(p.definitions["B"].fields[1], ctx) == "nothing"
+        @test CodeGenerators.jl_init_value(p.definitions["B"].fields[1], ctx) == "Ref{Union{Nothing,A}}(nothing)"
 
         s, p, ctx = translate_simple_proto("message A {} message B { optional A a = 1; }")
+        ctx._toplevel_name[] = "B"
         @test generate_struct_str(p.definitions["B"], ctx) == """
         struct B
             a::Union{Nothing,A}
         end
         """
+        @test CodeGenerators.jl_default_value(p.definitions["B"].fields[1], ctx) == "nothing"
+        @test CodeGenerators.jl_init_value(p.definitions["B"].fields[1], ctx) == "Ref{Union{Nothing,A}}(nothing)"
 
         s, p, ctx = translate_simple_proto("message A {} message B { required A a = 1; }")
+        ctx._toplevel_name[] = "B"
         @test generate_struct_str(p.definitions["B"], ctx) == """
         struct B
             a::A
         end
         """
+        @test CodeGenerators.jl_default_value(p.definitions["B"].fields[1], ctx) === nothing
+        @test CodeGenerators.jl_init_value(p.definitions["B"].fields[1], ctx) == "Ref{A}()"
     end
 
     @testset "Struct fields are optional when the type is self referential" begin
@@ -147,6 +172,8 @@ end
             a::Union{Nothing,B}
         end
         """
+        @test CodeGenerators.jl_default_value(p.definitions["B"].fields[1], ctx) == "nothing"
+        @test CodeGenerators.jl_init_value(p.definitions["B"].fields[1], ctx) == "Ref{Union{Nothing,B}}(nothing)"
 
         s, p, ctx = translate_simple_proto("message B { B a = 1; }", Options(force_required=Dict("main" => Set(["B.a"]))))
         @test generate_struct_str(p.definitions["B"], ctx) == """
@@ -154,6 +181,8 @@ end
             a::Union{Nothing,B}
         end
         """
+        @test CodeGenerators.jl_default_value(p.definitions["B"].fields[1], ctx) == "nothing"
+        @test CodeGenerators.jl_init_value(p.definitions["B"].fields[1], ctx) == "Ref{Union{Nothing,B}}(nothing)"
 
         s, p, ctx = translate_simple_proto("message B { required B a = 1; }")
         @test generate_struct_str(p.definitions["B"], ctx) == """
@@ -161,6 +190,8 @@ end
             a::Union{Nothing,B}
         end
         """
+        @test CodeGenerators.jl_default_value(p.definitions["B"].fields[1], ctx) == "nothing"
+        @test CodeGenerators.jl_init_value(p.definitions["B"].fields[1], ctx) == "Ref{Union{Nothing,B}}(nothing)"
 
         s, p, ctx = translate_simple_proto("message B { optional B a = 1; }")
         @test generate_struct_str(p.definitions["B"], ctx) == """
@@ -168,54 +199,97 @@ end
             a::Union{Nothing,B}
         end
         """
+        @test CodeGenerators.jl_default_value(p.definitions["B"].fields[1], ctx) == "nothing"
+        @test CodeGenerators.jl_init_value(p.definitions["B"].fields[1], ctx) == "Ref{Union{Nothing,B}}(nothing)"
     end
 
     @testset "Struct fields are optional when the type mutually recusrive dependency" begin
         s, p, ctx = translate_simple_proto("message A { B b = 1; } message B { A a = 1; }")
+        ctx._toplevel_name[] = "B"
         @test generate_struct_str(p.definitions["B"], ctx) == """
         struct B{T1<:var"##AbstractA"} <: var"##AbstractB"
             a::Union{Nothing,T1}
         end
         """
+        @test CodeGenerators.jl_default_value(p.definitions["B"].fields[1], ctx) == "nothing"
+        @test CodeGenerators.jl_init_value(p.definitions["B"].fields[1], ctx) == "Ref{Union{Nothing,A}}(nothing)"
+
+        ctx._toplevel_name[] = "A"
         @test generate_struct_str(p.definitions["A"], ctx) == """
         struct A <: var"##AbstractA"
             b::Union{Nothing,B}
         end
         """
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "nothing"
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "Ref{Union{Nothing,B}}(nothing)"
 
         s, p, ctx = translate_simple_proto("message A { B b = 1; } message B { A a = 1; }", Options(force_required=Dict("main" => Set(["B.a"]))))
+        ctx._toplevel_name[] = "B"
         @test generate_struct_str(p.definitions["B"], ctx) == """
         struct B{T1<:var"##AbstractA"} <: var"##AbstractB"
             a::Union{Nothing,T1}
         end
         """
+        @test CodeGenerators.jl_default_value(p.definitions["B"].fields[1], ctx) == "nothing"
+        @test CodeGenerators.jl_init_value(p.definitions["B"].fields[1], ctx) == "Ref{Union{Nothing,A}}(nothing)"
+        ctx._toplevel_name[] = "A"
         @test generate_struct_str(p.definitions["A"], ctx) == """
         struct A <: var"##AbstractA"
             b::Union{Nothing,B}
         end
         """
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "nothing"
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "Ref{Union{Nothing,B}}(nothing)"
 
         s, p, ctx = translate_simple_proto("message A { B b = 1; } message B { required A a = 1; }")
+        ctx._toplevel_name[] = "B"
         @test generate_struct_str(p.definitions["B"], ctx) == """
         struct B{T1<:var"##AbstractA"} <: var"##AbstractB"
             a::Union{Nothing,T1}
         end
         """
+        @test CodeGenerators.jl_default_value(p.definitions["B"].fields[1], ctx) == "nothing"
+        @test CodeGenerators.jl_init_value(p.definitions["B"].fields[1], ctx) == "Ref{Union{Nothing,A}}(nothing)"
+        ctx._toplevel_name[] = "A"
         @test generate_struct_str(p.definitions["A"], ctx) == """
         struct A <: var"##AbstractA"
             b::Union{Nothing,B}
         end
         """
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "nothing"
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "Ref{Union{Nothing,B}}(nothing)"
 
         s, p, ctx = translate_simple_proto("message A { B b = 1; } message B { optional A a = 1; }")
+        ctx._toplevel_name[] = "B"
         @test generate_struct_str(p.definitions["B"], ctx) == """
         struct B{T1<:var"##AbstractA"} <: var"##AbstractB"
             a::Union{Nothing,T1}
         end
         """
+        @test CodeGenerators.jl_default_value(p.definitions["B"].fields[1], ctx) == "nothing"
+        @test CodeGenerators.jl_init_value(p.definitions["B"].fields[1], ctx) == "Ref{Union{Nothing,A}}(nothing)"
+        ctx._toplevel_name[] = "A"
         @test generate_struct_str(p.definitions["A"], ctx) == """
         struct A <: var"##AbstractA"
             b::Union{Nothing,B}
+        end
+        """
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "nothing"
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "Ref{Union{Nothing,B}}(nothing)"
+    end
+
+    @testset "OneOf field codegen" begin
+        s, p, ctx = translate_simple_proto("message A { oneof a { int32 b = 1; int32 c = 2; uint32 d = 3; A e = 4; } }")
+        @test occursin("""
+        struct A{T1<:Union{Int32,UInt32,var"##AbstractA"}} <: var"##AbstractA"
+            a::Union{Nothing,OneOf{T1}}
+        end""", s)
+
+        s, p, ctx = translate_simple_proto("message A { oneof a { int32 b = 1; int32 c = 2; uint32 d = 3; } }")
+        ctx._toplevel_name[] = "A"
+        @test generate_struct_str(p.definitions["A"], ctx) == """
+        struct A{T1<:Union{Int32,UInt32}}
+            a::Union{Nothing,OneOf{T1}}
         end
         """
     end
@@ -225,6 +299,281 @@ end
         @test codegen_str(p.definitions["A"], ctx) == """
         @enumx A a=0 b=1
         """
+    end
+
+    @testset "Basic Types" begin
+        s, p, ctx = translate_simple_proto("message A { bool a = 1; }")
+        @test CodeGenerators.jl_typename(p.definitions["A"].fields[1], ctx) == "Bool"
+        s, p, ctx = translate_simple_proto("message A { uint32 a = 1; }")
+        @test CodeGenerators.jl_typename(p.definitions["A"].fields[1], ctx) == "UInt32"
+        s, p, ctx = translate_simple_proto("message A { uint64 a = 1; }")
+        @test CodeGenerators.jl_typename(p.definitions["A"].fields[1], ctx) == "UInt64"
+        s, p, ctx = translate_simple_proto("message A { int32 a = 1; }")
+        @test CodeGenerators.jl_typename(p.definitions["A"].fields[1], ctx) == "Int32"
+        s, p, ctx = translate_simple_proto("message A { int64 a = 1; }")
+        @test CodeGenerators.jl_typename(p.definitions["A"].fields[1], ctx) == "Int64"
+        s, p, ctx = translate_simple_proto("message A { sint32 a = 1; }")
+        @test CodeGenerators.jl_typename(p.definitions["A"].fields[1], ctx) == "Int32"
+        s, p, ctx = translate_simple_proto("message A { sint64 a = 1; }")
+        @test CodeGenerators.jl_typename(p.definitions["A"].fields[1], ctx) == "Int64"
+        s, p, ctx = translate_simple_proto("message A { fixed32 a = 1; }")
+        @test CodeGenerators.jl_typename(p.definitions["A"].fields[1], ctx) == "UInt32"
+        s, p, ctx = translate_simple_proto("message A { fixed64 a = 1; }")
+        @test CodeGenerators.jl_typename(p.definitions["A"].fields[1], ctx) == "UInt64"
+        s, p, ctx = translate_simple_proto("message A { sfixed32 a = 1; }")
+        @test CodeGenerators.jl_typename(p.definitions["A"].fields[1], ctx) == "Int32"
+        s, p, ctx = translate_simple_proto("message A { sfixed64 a = 1; }")
+        @test CodeGenerators.jl_typename(p.definitions["A"].fields[1], ctx) == "Int64"
+        s, p, ctx = translate_simple_proto("message A { float a = 1; }")
+        @test CodeGenerators.jl_typename(p.definitions["A"].fields[1], ctx) == "Float32"
+        s, p, ctx = translate_simple_proto("message A { double a = 1; }")
+        @test CodeGenerators.jl_typename(p.definitions["A"].fields[1], ctx) == "Float64"
+        s, p, ctx = translate_simple_proto("message A { string a = 1; }")
+        @test CodeGenerators.jl_typename(p.definitions["A"].fields[1], ctx) == "String"
+        s, p, ctx = translate_simple_proto("message A { bytes a = 1; }")
+        @test CodeGenerators.jl_typename(p.definitions["A"].fields[1], ctx) == "Vector{UInt8}"
+
+        s, p, ctx = translate_simple_proto("message A { repeated bool a = 1; }")
+        @test CodeGenerators.jl_typename(p.definitions["A"].fields[1], ctx) == "Vector{Bool}"
+        s, p, ctx = translate_simple_proto("message A { repeated uint32 a = 1; }")
+        @test CodeGenerators.jl_typename(p.definitions["A"].fields[1], ctx) == "Vector{UInt32}"
+        s, p, ctx = translate_simple_proto("message A { repeated uint64 a = 1; }")
+        @test CodeGenerators.jl_typename(p.definitions["A"].fields[1], ctx) == "Vector{UInt64}"
+        s, p, ctx = translate_simple_proto("message A { repeated int32 a = 1; }")
+        @test CodeGenerators.jl_typename(p.definitions["A"].fields[1], ctx) == "Vector{Int32}"
+        s, p, ctx = translate_simple_proto("message A { repeated int64 a = 1; }")
+        @test CodeGenerators.jl_typename(p.definitions["A"].fields[1], ctx) == "Vector{Int64}"
+        s, p, ctx = translate_simple_proto("message A { repeated sint32 a = 1; }")
+        @test CodeGenerators.jl_typename(p.definitions["A"].fields[1], ctx) == "Vector{Int32}"
+        s, p, ctx = translate_simple_proto("message A { repeated sint64 a = 1; }")
+        @test CodeGenerators.jl_typename(p.definitions["A"].fields[1], ctx) == "Vector{Int64}"
+        s, p, ctx = translate_simple_proto("message A { repeated fixed32 a = 1; }")
+        @test CodeGenerators.jl_typename(p.definitions["A"].fields[1], ctx) == "Vector{UInt32}"
+        s, p, ctx = translate_simple_proto("message A { repeated fixed64 a = 1; }")
+        @test CodeGenerators.jl_typename(p.definitions["A"].fields[1], ctx) == "Vector{UInt64}"
+        s, p, ctx = translate_simple_proto("message A { repeated sfixed32 a = 1; }")
+        @test CodeGenerators.jl_typename(p.definitions["A"].fields[1], ctx) == "Vector{Int32}"
+        s, p, ctx = translate_simple_proto("message A { repeated sfixed64 a = 1; }")
+        @test CodeGenerators.jl_typename(p.definitions["A"].fields[1], ctx) == "Vector{Int64}"
+        s, p, ctx = translate_simple_proto("message A { repeated float a = 1; }")
+        @test CodeGenerators.jl_typename(p.definitions["A"].fields[1], ctx) == "Vector{Float32}"
+        s, p, ctx = translate_simple_proto("message A { repeated double a = 1; }")
+        @test CodeGenerators.jl_typename(p.definitions["A"].fields[1], ctx) == "Vector{Float64}"
+        s, p, ctx = translate_simple_proto("message A { repeated string a = 1; }")
+        @test CodeGenerators.jl_typename(p.definitions["A"].fields[1], ctx) == "Vector{String}"
+        s, p, ctx = translate_simple_proto("message A { repeated bytes a = 1; }")
+        @test CodeGenerators.jl_typename(p.definitions["A"].fields[1], ctx) == "Vector{Vector{UInt8}}"
+
+        s, p, ctx = translate_simple_proto("message A { map<string,sint32> a = 1; }")
+        @test CodeGenerators.jl_typename(p.definitions["A"].fields[1], ctx) == "Dict{String,Int32}"
+        s, p, ctx = translate_simple_proto("message A { oneof a { int32 b = 1; int32 c = 2; uint32 d = 3; A e = 4; } }")
+        @test CodeGenerators.jl_typename(p.definitions["A"].fields[1], ctx) == "OneOf{Union{Int32,UInt32,A}}"
+        s, p, ctx = translate_simple_proto("message A { repeated A a = 1; }")
+        @test CodeGenerators.jl_typename(p.definitions["A"].fields[1], ctx) == "Vector{A}"
+    end
+
+    @testset "Default values" begin
+        s, p, ctx = translate_simple_proto("message A { bool a = 1; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "false"
+        s, p, ctx = translate_simple_proto("message A { uint32 a = 1; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "zero(UInt32)"
+        s, p, ctx = translate_simple_proto("message A { uint64 a = 1; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "zero(UInt64)"
+        s, p, ctx = translate_simple_proto("message A { int32 a = 1; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "zero(Int32)"
+        s, p, ctx = translate_simple_proto("message A { int64 a = 1; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "zero(Int64)"
+        s, p, ctx = translate_simple_proto("message A { sint32 a = 1; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "zero(Int32)"
+        s, p, ctx = translate_simple_proto("message A { sint64 a = 1; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "zero(Int64)"
+        s, p, ctx = translate_simple_proto("message A { fixed32 a = 1; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "zero(UInt32)"
+        s, p, ctx = translate_simple_proto("message A { fixed64 a = 1; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "zero(UInt64)"
+        s, p, ctx = translate_simple_proto("message A { sfixed32 a = 1; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "zero(Int32)"
+        s, p, ctx = translate_simple_proto("message A { sfixed64 a = 1; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "zero(Int64)"
+        s, p, ctx = translate_simple_proto("message A { float a = 1; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "zero(Float32)"
+        s, p, ctx = translate_simple_proto("message A { double a = 1; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "zero(Float64)"
+        s, p, ctx = translate_simple_proto("message A { string a = 1; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "\"\""
+        s, p, ctx = translate_simple_proto("message A { bytes a = 1; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "UInt8[]"
+
+        s, p, ctx = translate_simple_proto("message A { bool a = 1 [default=true]; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "true"
+        s, p, ctx = translate_simple_proto("message A { uint32 a = 1 [default=1]; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "UInt32(0x00000001)"
+        s, p, ctx = translate_simple_proto("message A { uint64 a = 1 [default=1]; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "UInt64(0x0000000000000001)"
+        s, p, ctx = translate_simple_proto("message A { int32 a = 1 [default=1]; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "Int32(1)"
+        s, p, ctx = translate_simple_proto("message A { int64 a = 1 [default=1]; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "Int64(1)"
+        s, p, ctx = translate_simple_proto("message A { sint32 a = 1 [default=1]; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "Int32(1)"
+        s, p, ctx = translate_simple_proto("message A { sint64 a = 1 [default=1]; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "Int64(1)"
+        s, p, ctx = translate_simple_proto("message A { fixed32 a = 1 [default=1]; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "UInt32(0x00000001)"
+        s, p, ctx = translate_simple_proto("message A { fixed64 a = 1 [default=1]; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "UInt64(0x0000000000000001)"
+        s, p, ctx = translate_simple_proto("message A { sfixed32 a = 1 [default=1]; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "Int32(1)"
+        s, p, ctx = translate_simple_proto("message A { sfixed64 a = 1 [default=1]; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "Int64(1)"
+        s, p, ctx = translate_simple_proto("message A { float a = 1 [default=1.0]; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "Float32(1.0)"
+        s, p, ctx = translate_simple_proto("message A { double a = 1  [default=1.0]; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "Float64(1.0)"
+        s, p, ctx = translate_simple_proto("message A { string a = 1 [default=\"1\"]; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "\"1\""
+        s, p, ctx = translate_simple_proto("message A { bytes a = 1 [default=\"1\"]; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "b\"1\""
+
+        s, p, ctx = translate_simple_proto("message A { repeated bool a = 1; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "Vector{Bool}()"
+        s, p, ctx = translate_simple_proto("message A { repeated uint32 a = 1; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "Vector{UInt32}()"
+        s, p, ctx = translate_simple_proto("message A { repeated uint64 a = 1; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "Vector{UInt64}()"
+        s, p, ctx = translate_simple_proto("message A { repeated int32 a = 1; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "Vector{Int32}()"
+        s, p, ctx = translate_simple_proto("message A { repeated int64 a = 1; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "Vector{Int64}()"
+        s, p, ctx = translate_simple_proto("message A { repeated sint32 a = 1; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "Vector{Int32}()"
+        s, p, ctx = translate_simple_proto("message A { repeated sint64 a = 1; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "Vector{Int64}()"
+        s, p, ctx = translate_simple_proto("message A { repeated fixed32 a = 1; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "Vector{UInt32}()"
+        s, p, ctx = translate_simple_proto("message A { repeated fixed64 a = 1; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "Vector{UInt64}()"
+        s, p, ctx = translate_simple_proto("message A { repeated sfixed32 a = 1; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "Vector{Int32}()"
+        s, p, ctx = translate_simple_proto("message A { repeated sfixed64 a = 1; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "Vector{Int64}()"
+        s, p, ctx = translate_simple_proto("message A { repeated float a = 1; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "Vector{Float32}()"
+        s, p, ctx = translate_simple_proto("message A { repeated double a = 1; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "Vector{Float64}()"
+        s, p, ctx = translate_simple_proto("message A { repeated string a = 1; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "Vector{String}()"
+        s, p, ctx = translate_simple_proto("message A { repeated bytes a = 1; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "Vector{Vector{UInt8}}()"
+
+        s, p, ctx = translate_simple_proto("message A { map<string,sint32> a = 1; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "Dict{String,Int32}()"
+        s, p, ctx = translate_simple_proto("message A { oneof a { int32 b = 1; } }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "nothing"
+        s, p, ctx = translate_simple_proto("message A { repeated A a = 1; }")
+        @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "Vector{A}()"
+    end
+
+    @testset "Initial values" begin
+        s, p, ctx = translate_simple_proto("message A { bool a = 1; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "false"
+        s, p, ctx = translate_simple_proto("message A { uint32 a = 1; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "zero(UInt32)"
+        s, p, ctx = translate_simple_proto("message A { uint64 a = 1; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "zero(UInt64)"
+        s, p, ctx = translate_simple_proto("message A { int32 a = 1; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "zero(Int32)"
+        s, p, ctx = translate_simple_proto("message A { int64 a = 1; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "zero(Int64)"
+        s, p, ctx = translate_simple_proto("message A { sint32 a = 1; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "zero(Int32)"
+        s, p, ctx = translate_simple_proto("message A { sint64 a = 1; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "zero(Int64)"
+        s, p, ctx = translate_simple_proto("message A { fixed32 a = 1; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "zero(UInt32)"
+        s, p, ctx = translate_simple_proto("message A { fixed64 a = 1; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "zero(UInt64)"
+        s, p, ctx = translate_simple_proto("message A { sfixed32 a = 1; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "zero(Int32)"
+        s, p, ctx = translate_simple_proto("message A { sfixed64 a = 1; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "zero(Int64)"
+        s, p, ctx = translate_simple_proto("message A { float a = 1; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "zero(Float32)"
+        s, p, ctx = translate_simple_proto("message A { double a = 1; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "zero(Float64)"
+        s, p, ctx = translate_simple_proto("message A { string a = 1; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "\"\""
+        s, p, ctx = translate_simple_proto("message A { bytes a = 1; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "UInt8[]"
+
+        s, p, ctx = translate_simple_proto("message A { bool a = 1 [default=true]; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "true"
+        s, p, ctx = translate_simple_proto("message A { uint32 a = 1 [default=1]; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "UInt32(0x00000001)"
+        s, p, ctx = translate_simple_proto("message A { uint64 a = 1 [default=1]; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "UInt64(0x0000000000000001)"
+        s, p, ctx = translate_simple_proto("message A { int32 a = 1 [default=1]; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "Int32(1)"
+        s, p, ctx = translate_simple_proto("message A { int64 a = 1 [default=1]; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "Int64(1)"
+        s, p, ctx = translate_simple_proto("message A { sint32 a = 1 [default=1]; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "Int32(1)"
+        s, p, ctx = translate_simple_proto("message A { sint64 a = 1 [default=1]; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "Int64(1)"
+        s, p, ctx = translate_simple_proto("message A { fixed32 a = 1 [default=1]; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "UInt32(0x00000001)"
+        s, p, ctx = translate_simple_proto("message A { fixed64 a = 1 [default=1]; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "UInt64(0x0000000000000001)"
+        s, p, ctx = translate_simple_proto("message A { sfixed32 a = 1 [default=1]; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "Int32(1)"
+        s, p, ctx = translate_simple_proto("message A { sfixed64 a = 1 [default=1]; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "Int64(1)"
+        s, p, ctx = translate_simple_proto("message A { float a = 1 [default=1.0]; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "Float32(1.0)"
+        s, p, ctx = translate_simple_proto("message A { double a = 1  [default=1.0]; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "Float64(1.0)"
+        s, p, ctx = translate_simple_proto("message A { string a = 1 [default=\"1\"]; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "\"1\""
+        s, p, ctx = translate_simple_proto("message A { bytes a = 1 [default=\"1\"]; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "b\"1\""
+
+        s, p, ctx = translate_simple_proto("message A { repeated bool a = 1; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "PB.BufferedVector{Bool}()"
+        s, p, ctx = translate_simple_proto("message A { repeated uint32 a = 1; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "PB.BufferedVector{UInt32}()"
+        s, p, ctx = translate_simple_proto("message A { repeated uint64 a = 1; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "PB.BufferedVector{UInt64}()"
+        s, p, ctx = translate_simple_proto("message A { repeated int32 a = 1; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "PB.BufferedVector{Int32}()"
+        s, p, ctx = translate_simple_proto("message A { repeated int64 a = 1; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "PB.BufferedVector{Int64}()"
+        s, p, ctx = translate_simple_proto("message A { repeated sint32 a = 1; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "PB.BufferedVector{Int32}()"
+        s, p, ctx = translate_simple_proto("message A { repeated sint64 a = 1; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "PB.BufferedVector{Int64}()"
+        s, p, ctx = translate_simple_proto("message A { repeated fixed32 a = 1; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "PB.BufferedVector{UInt32}()"
+        s, p, ctx = translate_simple_proto("message A { repeated fixed64 a = 1; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "PB.BufferedVector{UInt64}()"
+        s, p, ctx = translate_simple_proto("message A { repeated sfixed32 a = 1; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "PB.BufferedVector{Int32}()"
+        s, p, ctx = translate_simple_proto("message A { repeated sfixed64 a = 1; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "PB.BufferedVector{Int64}()"
+        s, p, ctx = translate_simple_proto("message A { repeated float a = 1; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "PB.BufferedVector{Float32}()"
+        s, p, ctx = translate_simple_proto("message A { repeated double a = 1; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "PB.BufferedVector{Float64}()"
+        s, p, ctx = translate_simple_proto("message A { repeated string a = 1; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "PB.BufferedVector{String}()"
+        s, p, ctx = translate_simple_proto("message A { repeated bytes a = 1; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "PB.BufferedVector{Vector{UInt8}}()"
+
+        s, p, ctx = translate_simple_proto("message A { repeated A a = 1; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "PB.BufferedVector{A}()"
+        s, p, ctx = translate_simple_proto("message A { map<string,sint32> a = 1; }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "Dict{String,Int32}()"
+        s, p, ctx = translate_simple_proto("message A { oneof a { int32 b = 1; } }")
+        @test CodeGenerators.jl_init_value(p.definitions["A"].fields[1], ctx) == "nothing"
     end
 
     @testset "Metadata methods" begin
@@ -245,12 +594,13 @@ end
         end
 
         @testset "metadata_methods are generated when needed" begin
-            s, p, ctx = translate_simple_proto("message A { reserved \"b\"; reserved 2; extensions 4 to max; A a = 1; oneof o { sfixed32 s = 3 [default = -1]; }}")
+            s, p, ctx = translate_simple_proto("message A { reserved \"b\"; reserved 2; extensions 4 to max; A a = 1; oneof o { sfixed32 s = 3 [default = -1]; }}", Options(add_kwarg_constructors=true))
             @test strify(CodeGenerators.maybe_generate_reserved_fields_method,          p.definitions["A"])      == "PB.reserved_fields(::Type{A}) = (names = [\"b\"], numbers = Union{UnitRange{Int64}, Int64}[2])\n"
             @test strify(CodeGenerators.maybe_generate_extendable_field_numbers_method, p.definitions["A"])      == "PB.extendable_field_numbers(::Type{A}) = Union{UnitRange{Int64}, Int64}[4:536870911]\n"
-            @test strify(CodeGenerators.maybe_generate_default_values_method,           p.definitions["A"], ctx) == "PB.default_values(::Type{A}) = (;a = Ref{Union{Nothing,A}}(nothing), s = Int32(-1))\n"
+            @test strify(CodeGenerators.maybe_generate_default_values_method,           p.definitions["A"], ctx) == "PB.default_values(::Type{A}) = (;a = nothing, s = Int32(-1))\n"
             @test strify(CodeGenerators.maybe_generate_oneof_field_types_method,        p.definitions["A"], ctx) == "PB.oneof_field_types(::Type{A}) = (;\n    o = (;s=Int32)\n)\n"
             @test strify(CodeGenerators.maybe_generate_field_numbers_method,            p.definitions["A"])      == "PB.field_numbers(::Type{A}) = (;a = 1, s = 3)\n"
+            @test strify(CodeGenerators.maybe_generate_kwarg_constructor_method,        p.definitions["A"], ctx) == "A(;a = nothing, o = nothing) = A(a, o)\n"
         end
     end
 end

--- a/test/test_parser.jl
+++ b/test/test_parser.jl
@@ -15,8 +15,13 @@ function translate_simple_proto(str::String, options=Options())
     s = String(take!(buf))
     s = join(filter!(!startswith(r"#|$^"), split(s, '\n')), '\n')
     imports = Set{String}(Iterators.map(i->namespace(d[i]), import_paths(p)))
-    ctx = Context(p, r.import_path, imports, d, copy(p.cyclic_definitions), options)
-    s, p, ctx
+    ctx = Context(
+        p, r.import_path, imports, d,
+        copy(p.cyclic_definitions),
+        Ref(get(p.sorted_definitions, length(p.sorted_definitions), "")),
+        options
+    )
+    return s, p, ctx
 end
 
 function translate_simple_proto(str::String, deps::Dict{String,String}, options=Options())
@@ -36,8 +41,13 @@ function translate_simple_proto(str::String, deps::Dict{String,String}, options=
     s = String(take!(buf))
     s = join(filter!(!startswith(r"#|$^"), split(s, '\n')), '\n')
     imports = Set{String}(Iterators.map(i->namespace(d[i]), import_paths(p)))
-    ctx = Context(p, r.import_path, imports, d, copy(p.cyclic_definitions), options)
-    s, d, ctx
+    ctx = Context(
+        p, r.import_path, imports, d,
+        copy(p.cyclic_definitions),
+        Ref(get(p.sorted_definitions, length(p.sorted_definitions), "")),
+        options
+    )
+    return s, d, ctx
 end
 
 @testset "Parsers" begin


### PR DESCRIPTION
To make transitions from current `ProtoBuf.jl` a little easier, the `add_kwarg_constructors` flag can be set to generate kwarg only constructors for the generated structs. The keyword arguments are optional with the exception of `required` message-fields which have no default value.

The `default_values` metadata method is also a bit more helpful now as it returns the actual _default_ values and not the "_initial_" values used for decoding, i.e. it returns `Vector`s instead of our `BufferedVector`s etc.)